### PR TITLE
Add tokenizer and indenter tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "TurboLispREPL",
+    products: [
+        .library(name: "TurboLispREPL", targets: ["TurboLispREPL"]),
+    ],
+    targets: [
+        .target(name: "TurboLispREPL", dependencies: []),
+        .testTarget(name: "TurboLispREPLTests", dependencies: ["TurboLispREPL"]),
+    ]
+)
+

--- a/Sources/TurboLispREPL/AST.swift
+++ b/Sources/TurboLispREPL/AST.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum Expr: Equatable {
+    case symbol(String)
+    case string(String)
+    case list([Expr])
+}
+

--- a/Sources/TurboLispREPL/Indenter.swift
+++ b/Sources/TurboLispREPL/Indenter.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public enum Indenter {
+    public static func styles(for code: String, indentWidth: Int = 2) -> [NSParagraphStyle] {
+        var level = 0
+        var styles: [NSParagraphStyle] = []
+        let lines = code.split(separator: "\n", omittingEmptySubsequences: false)
+        for lineSub in lines {
+            var line = String(lineSub)
+            if let commentIndex = line.firstIndex(of: ";") {
+                line = String(line[..<commentIndex])
+            }
+            var i = line.startIndex
+            while i < line.endIndex {
+                let c = line[i]
+                if c == " " || c == "\t" {
+                    i = line.index(after: i)
+                    continue
+                }
+                if c == ")" {
+                    level = max(0, level - 1)
+                    i = line.index(after: i)
+                    continue
+                }
+                break
+            }
+            var style = NSMutableParagraphStyle()
+            style.headIndent = CGFloat(level * indentWidth)
+            styles.append(style)
+            var inString = false
+            while i < line.endIndex {
+                let c = line[i]
+                if c == "\"" {
+                    inString.toggle()
+                } else if !inString {
+                    if c == "(" { level += 1 }
+                    else if c == ")" { level = max(0, level - 1) }
+                }
+                i = line.index(after: i)
+            }
+        }
+        return styles
+    }
+}
+

--- a/Sources/TurboLispREPL/ParagraphStyleCompat.swift
+++ b/Sources/TurboLispREPL/ParagraphStyleCompat.swift
@@ -1,0 +1,14 @@
+#if os(Linux)
+import Foundation
+
+public struct SimpleParagraphStyle {
+    public var headIndent: CGFloat = 0
+    public init() {}
+}
+
+public typealias NSParagraphStyle = SimpleParagraphStyle
+public typealias NSMutableParagraphStyle = SimpleParagraphStyle
+#else
+import Foundation
+#endif
+

--- a/Sources/TurboLispREPL/Parser.swift
+++ b/Sources/TurboLispREPL/Parser.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public enum ParserError: Error {
+    case unexpectedEOF
+    case unmatchedParen
+}
+
+public enum Parser {
+    public static func parse(_ input: String) throws -> Expr {
+        let tokens = Tokenizer.tokenize(input).filter { $0.kind != .comment }
+        var index = 0
+        func parseExpr() throws -> Expr {
+            guard index < tokens.count else { throw ParserError.unexpectedEOF }
+            let tok = tokens[index]; index += 1
+            switch tok.kind {
+            case .paren:
+                if tok.value == "(" {
+                    var list: [Expr] = []
+                    while index < tokens.count {
+                        let next = tokens[index]
+                        if next.kind == .paren && next.value == ")" {
+                            index += 1
+                            break
+                        }
+                        list.append(try parseExpr())
+                    }
+                    return .list(list)
+                } else {
+                    throw ParserError.unmatchedParen
+                }
+            case .string:
+                let inner = String(tok.value.dropFirst().dropLast())
+                return .string(inner)
+            default:
+                return .symbol(tok.value)
+            }
+        }
+        let expr = try parseExpr()
+        return expr
+    }
+}
+

--- a/Sources/TurboLispREPL/Printer.swift
+++ b/Sources/TurboLispREPL/Printer.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public enum Printer {
+    public static func print(_ expr: Expr) -> String {
+        switch expr {
+        case .symbol(let s):
+            return s
+        case .string(let s):
+            return "\"\(s)\""
+        case .list(let elems):
+            return "(" + elems.map { print($0) }.joined(separator: " ") + ")"
+        }
+    }
+}
+

--- a/Sources/TurboLispREPL/Tokenizer.swift
+++ b/Sources/TurboLispREPL/Tokenizer.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public struct Token {
+    public enum Kind: String {
+        case paren
+        case string
+        case comment
+        case symbol
+    }
+    public let kind: Kind
+    public let value: String
+}
+
+public enum Tokenizer {
+    public static func tokenize(_ input: String) -> [Token] {
+        var tokens: [Token] = []
+        var index = input.startIndex
+        let end = input.endIndex
+        while index < end {
+            let char = input[index]
+            if char == ";" {
+                let start = index
+                while index < end && input[index] != "\n" {
+                    index = input.index(after: index)
+                }
+                let comment = String(input[start..<index])
+                tokens.append(Token(kind: .comment, value: comment))
+            } else if char == "\"" {
+                var j = input.index(after: index)
+                while j < end && input[j] != "\"" {
+                    j = input.index(after: j)
+                }
+                if j < end { j = input.index(after: j) }
+                let str = String(input[index..<j])
+                tokens.append(Token(kind: .string, value: str))
+                index = j
+                continue
+            } else if char == "(" || char == ")" {
+                tokens.append(Token(kind: .paren, value: String(char)))
+                index = input.index(after: index)
+                continue
+            } else if char.isWhitespace {
+                index = input.index(after: index)
+                continue
+            } else {
+                var j = index
+                while j < end {
+                    let c = input[j]
+                    if c.isWhitespace || c == "(" || c == ")" || c == ";" {
+                        break
+                    }
+                    j = input.index(after: j)
+                }
+                let symbol = String(input[index..<j])
+                tokens.append(Token(kind: .symbol, value: symbol))
+                index = j
+                continue
+            }
+            index = input.index(after: index)
+        }
+        return tokens
+    }
+}
+
+extension Character {
+    var isWhitespace: Bool {
+        return unicodeScalars.allSatisfy { CharacterSet.whitespacesAndNewlines.contains($0) }
+    }
+}
+

--- a/Tests/TurboLispREPLTests/IndenterTests.swift
+++ b/Tests/TurboLispREPLTests/IndenterTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import TurboLispREPL
+
+final class IndenterTests: XCTestCase {
+    func testIndentationLevels() {
+        let code = """
+(defun foo (x)
+  (let ((y 1))
+    (if x
+        y
+        0))
+)
+"""
+        let styles = Indenter.styles(for: code)
+        XCTAssertEqual(styles.count, 6)
+        XCTAssertEqual(styles[0].headIndent, 0)
+        XCTAssertEqual(styles[1].headIndent, 2)
+        XCTAssertEqual(styles[2].headIndent, 4)
+        XCTAssertEqual(styles[3].headIndent, 6)
+        XCTAssertEqual(styles[4].headIndent, 6)
+        XCTAssertEqual(styles[5].headIndent, 0)
+    }
+}
+

--- a/Tests/TurboLispREPLTests/TokenizerTests.swift
+++ b/Tests/TurboLispREPLTests/TokenizerTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import TurboLispREPL
+
+final class TokenizerTests: XCTestCase {
+    func testTokenizationTranscript() {
+        let code = """
+(defun greet ()
+  (print "Hello") ; Greet
+)
+"""
+        let tokens = Tokenizer.tokenize(code)
+        let transcript = tokens.map { "\($0.kind.rawValue):\($0.value)" }.joined(separator: "\n")
+        let expected = #"""
+paren:(
+symbol:defun
+symbol:greet
+paren:(
+paren:)
+paren:(
+symbol:print
+string:"Hello"
+paren:)
+comment:; Greet
+paren:)
+"""#
+        XCTAssertEqual(transcript, expected)
+    }
+
+    func testPrinterRoundTripFuzz() throws {
+        for _ in 0..<100 {
+            let expr = randomExpr(depth: 3)
+            let printed = Printer.print(expr)
+            let parsed = try Parser.parse(printed)
+            XCTAssertEqual(parsed, expr)
+        }
+    }
+
+    private func randomExpr(depth: Int) -> Expr {
+        if depth == 0 {
+            return Bool.random() ? .symbol(randomSymbol()) : .string(randomString())
+        }
+        let choice = Int.random(in: 0...2)
+        switch choice {
+        case 0:
+            return .symbol(randomSymbol())
+        case 1:
+            return .string(randomString())
+        default:
+            let count = Int.random(in: 0...3)
+            var items: [Expr] = []
+            for _ in 0..<count {
+                items.append(randomExpr(depth: depth - 1))
+            }
+            return .list(items)
+        }
+    }
+
+    private func randomSymbol() -> String {
+        let letters = Array("abcdefghijklmnopqrstuvwxyz")
+        let length = Int.random(in: 1...3)
+        return String((0..<length).map { _ in letters.randomElement()! })
+    }
+
+    private func randomString() -> String {
+        let letters = Array("abcdefghijklmnopqrstuvwxyz")
+        let length = Int.random(in: 0...3)
+        return String((0..<length).map { _ in letters.randomElement()! })
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tokenizer golden transcript tests
- test indentation of defun, let, and if
- add fuzz test for printer round-trip

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68aba563c84c832faadfb59151752341