### PR TITLE
Add tokenizer edge case tests

### DIFF
--- a/Tests/TurboLispREPLTests/IndenterTests.swift
+++ b/Tests/TurboLispREPLTests/IndenterTests.swift
@@ -111,6 +111,63 @@ final class IndenterTests: XCTestCase {
         
         XCTAssertGreaterThan(tokenCount, 0, "Should parse tokens")
     }
+
+    func testDeeplyNestedForms() {
+        let depth = 50
+        let source = String(repeating: "(", count: depth) + String(repeating: ")", count: depth)
+        let tokenizer = StandardLispTokenizer()
+        tokenizer.reset(with: source)
+        var openCount = 0
+        var closeCount = 0
+        while let token = tokenizer.nextToken() {
+            switch token.kind {
+            case .open:
+                openCount += 1
+            case .close:
+                closeCount += 1
+            default:
+                break
+            }
+        }
+        XCTAssertEqual(openCount, depth, "All opening parens should be tokenized")
+        XCTAssertEqual(closeCount, depth, "All closing parens should be tokenized")
+    }
+
+    func testUnmatchedParentheses() {
+        let missingClose = "(foo (bar 1)"
+        let extraClose = "(foo 1))"
+        let tokenizer = StandardLispTokenizer()
+
+        tokenizer.reset(with: missingClose)
+        var openCount = 0
+        var closeCount = 0
+        while let token = tokenizer.nextToken() {
+            switch token.kind {
+            case .open:
+                openCount += 1
+            case .close:
+                closeCount += 1
+            default:
+                break
+            }
+        }
+        XCTAssertTrue(openCount > closeCount, "Missing closing paren should leave more opens than closes")
+
+        tokenizer.reset(with: extraClose)
+        openCount = 0
+        closeCount = 0
+        while let token = tokenizer.nextToken() {
+            switch token.kind {
+            case .open:
+                openCount += 1
+            case .close:
+                closeCount += 1
+            default:
+                break
+            }
+        }
+        XCTAssertTrue(closeCount > openCount, "Extra closing paren should yield more closes than opens")
+    }
 }
 
 #endif

--- a/Tests/TurboLispREPLTests/TokenizerTests.swift
+++ b/Tests/TurboLispREPLTests/TokenizerTests.swift
@@ -12,4 +12,20 @@ final class TokenizerTests: XCTestCase {
             TokenKind.paren.rawValue
         ])
     }
+
+    func testMalformedStringIsTokenizedToEnd() {
+        let source = "(print \"oops"
+        let tokens = LispTokenizer.tokenize(source)
+        XCTAssertEqual(tokens.map { $0.kind }, [
+            TokenKind.paren.rawValue,
+            TokenKind.string.rawValue
+        ])
+    }
+
+    func testUnterminatedCommentReachesEOF() {
+        let source = "; this comment never ends"
+        let tokens = LispTokenizer.tokenize(source)
+        XCTAssertEqual(tokens.count, 1)
+        XCTAssertEqual(tokens.first?.kind, TokenKind.comment.rawValue)
+    }
 }


### PR DESCRIPTION
## Summary
- add tests for deeply nested forms
- verify tokenizer behaviour with unmatched parentheses
- ensure malformed strings and comments are tokenized gracefully

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68acf30e9d94832fa2defb309775c9bc