### PR TITLE
Add explicit comment tokens to reader

### DIFF
--- a/Sources/TurboLispREPL/Reader/LispIndenter.swift
+++ b/Sources/TurboLispREPL/Reader/LispIndenter.swift
@@ -9,6 +9,7 @@ public struct LispToken {
         case open(symbol: String)
         case close
         case atom(String)
+        case comment(String)
     }
     public let kind: Kind
     public let range: NSRange
@@ -83,7 +84,7 @@ public final class LispIndenter {
                 applyIndent(rule, range: token.range, in: textStorage)
             case .close:
                 if stack.count > 1 { stack.removeLast() }
-            case .atom:
+            case .atom, .comment:
                 break
             }
         }

--- a/Sources/TurboLispREPL/Reader/LispTokenizer.swift
+++ b/Sources/TurboLispREPL/Reader/LispTokenizer.swift
@@ -93,8 +93,8 @@ public final class StandardLispTokenizer: LispTokenizerProtocol {
                 currentIndex += 1
             }
             let range = NSRange(location: startIndex, length: currentIndex - startIndex)
-            // Return as atom for now (comments are atoms in this context)
-            return LispToken(kind: .atom(String(characters[startIndex..<currentIndex])), range: range)
+            let commentText = String(characters[startIndex..<currentIndex])
+            return LispToken(kind: .comment(commentText), range: range)
             
         case "\"":
             // String literal

--- a/Tests/TurboLispREPLTests/IndenterTests.swift
+++ b/Tests/TurboLispREPLTests/IndenterTests.swift
@@ -101,15 +101,33 @@ final class IndenterTests: XCTestCase {
     func testStandardLispTokenizer() {
         let tokenizer = StandardLispTokenizer()
         let source = "(let ((x 1)))"
-        
+
         tokenizer.reset(with: source)
-        
+
         var tokenCount = 0
         while let _ = tokenizer.nextToken() {
             tokenCount += 1
         }
-        
+
         XCTAssertGreaterThan(tokenCount, 0, "Should parse tokens")
+    }
+
+    func testStandardLispTokenizerHandlesComments() {
+        let tokenizer = StandardLispTokenizer()
+        let source = "; hello\n()"
+        tokenizer.reset(with: source)
+
+        guard let token = tokenizer.nextToken() else {
+            XCTFail("Expected a comment token")
+            return
+        }
+
+        switch token.kind {
+        case .comment(let text):
+            XCTAssertEqual(text, "; hello")
+        default:
+            XCTFail("First token should be a comment")
+        }
     }
 
     func testDeeplyNestedForms() {


### PR DESCRIPTION
## Summary
- Add `.comment` case to `LispToken.Kind`
- Emit `.comment` tokens from `StandardLispTokenizer`
- Cover comment handling in tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ad1b433338832f86c9334d1dcc3bb6