### PR TITLE
Expand tokenizer symbol character set

### DIFF
--- a/Sources/TurboLispREPL/Reader/LispTokenizer.swift
+++ b/Sources/TurboLispREPL/Reader/LispTokenizer.swift
@@ -34,6 +34,10 @@ public final class StandardLispTokenizer: LispTokenizerProtocol {
         self.characters = Array(source)
         self.currentIndex = 0
     }
+
+    private func isSymbolChar(_ ch: Character) -> Bool {
+        return ch.isLetter || ch.isNumber || "-_*+?!:".contains(ch)
+    }
     
     public func nextToken() -> LispToken? {
         // Skip whitespace except newlines (they might be significant for indentation)
@@ -71,7 +75,7 @@ public final class StandardLispTokenizer: LispTokenizerProtocol {
             // Extract the symbol
             while peekIndex < characters.count {
                 let peekCh = characters[peekIndex]
-                if peekCh.isLetter || peekCh.isNumber || peekCh == "-" || peekCh == "_" {
+                if isSymbolChar(peekCh) {
                     symbol.append(peekCh)
                     peekIndex += 1
                 } else {

--- a/Tests/TurboLispREPLTests/TokenizerTests.swift
+++ b/Tests/TurboLispREPLTests/TokenizerTests.swift
@@ -28,4 +28,19 @@ final class TokenizerTests: XCTestCase {
         XCTAssertEqual(tokens.count, 1)
         XCTAssertEqual(tokens.first?.kind, TokenKind.comment.rawValue)
     }
+
+    func testSymbolExtractionAllowsSpecialCharacters() {
+        let tokenizer = StandardLispTokenizer()
+        let source = "(* 1 2) (+ 3 4) (contains? xs) (save! y) (:keyword 42)"
+        tokenizer.reset(with: source)
+
+        var symbols: [String] = []
+        while let token = tokenizer.nextToken() {
+            if case .open(let sym) = token.kind {
+                symbols.append(sym)
+            }
+        }
+
+        XCTAssertEqual(symbols, ["*", "+", "contains?", "save!", ":keyword"])
+    }
 }


### PR DESCRIPTION
## Summary
- allow punctuation like `*`, `+`, `?`, `!`, and `:` in symbols by adding `isSymbolChar`
- use `isSymbolChar` when extracting symbol names after `(`
- test tokenizer with special symbol characters

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68ad1b48413c832fa03dfe1eca85af95